### PR TITLE
FIX: Newton's method singularities causing failure to lower points to 2D in NURBS surfaces.

### DIFF
--- a/nurbs/src/sampled_surface.rs
+++ b/nurbs/src/sampled_surface.rs
@@ -94,9 +94,12 @@ impl<const N: usize> SampledSurface<N>
                 dot(&S_u, &S_v) + dot(&r, &S_uv),
                 length2(&S_v) + dot(&r, &S_vv),
             );
-            let delta_i = match J_i.try_inverse() {
-                None => return None,
-                Some(m) => m * K_i,
+            // By using pseudo_inverse() rather than try_inverse() we can avoid the singularities
+            // that pop up from time to time when using Newton's method.
+            let delta_i = if let Ok(inverse) = J_i.pseudo_inverse(1e-4) {
+                inverse * K_i
+            } else {
+                return None;
             };
             let mut uv_ip1 = uv_i + delta_i;
 


### PR DESCRIPTION
Frequently BSpline surfaces failed to lower points to 2D because of the use of try_inverse() to compute the gradient `delta_i` - this is because using this method, if you arrive at a stationary point, `J_i` stops being invertible. 

The solution here uses the pseudo inverse, which basically resolves to [0 0; 0 0], making delta_i = 0 (as expected), rather than returning None. 

Another option would be to simply set delta_i = **0** when try_inverse is `None`, however the psuedo-inverse is preffered because it sets only the singular values below epsilon (chosen arbitrarily here to `1e-4`) of the inverted matrix to 0. This typically results in the **0** matrix, maybe there are times when it doesn't and you'd stop prematurely, I couldn't tell you for certain if that ever happens, can't hurt though...