### PR TITLE
CDT: Add test cases for problematic input

### DIFF
--- a/cdt/src/triangulate.rs
+++ b/cdt/src/triangulate.rs
@@ -1532,4 +1532,31 @@ mod tests {
             assert!(e == Error::OpenContour);
         }
     }
+    
+    #[test]
+    fn problematic_hull_case() {
+        // This set of points triggered an error in the Hull, causing the data
+        // structure to become malformed.
+        let pts = [
+            (-4.3, -2.0900000000000003),
+            (-6.8, -2.09),
+            (-11.1, -2.09),
+        ];
+        let t = Triangulation::build(&pts).expect("Could not construct");
+        t.check();
+    }
+
+    #[test]
+    fn problematic_cdt_case() {
+        // This set of points triggers an assertion in the triangulator,
+        // possibly related to overlapping edges
+        let pts = [
+            (-4.3, -2.0900000000000003),
+            (-6.8, -2.09),
+            (-11.099999999999998, -2.09),
+            (0.0, 0.0),
+        ];
+        let t = Triangulation::build(&pts).expect("Could not construct");
+        t.check();
+    }
 }


### PR DESCRIPTION
Foxtrot fails when you try to open the Raspberry Pi 4 Model B STEP file. This isn't the Model 3 from the demo. The STEP file can be found here: https://grabcad.com/library/raspberry-pi-4-model-b-1

I have isolated the failure to two problematic test cases in the cdt package. This PR does not fix the errors - it only adds test cases to trigger the errors.

- problematic_hull_case: This data causes a malformed Hull data structure to be generated. The error can be detected by calling hull.check after the hull has been built but before running the triangulator.
- problematic_cdt_case: This data causes the triangulator to fail with `assertion failed: edge_r.dst == edge_l.src`